### PR TITLE
Add classic Firefox layout

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1,36 +1,46 @@
-#nav-bar{background:transparent!important}
-#navigator-toolbox::after {
-     border-bottom: 0px !important;
- }
- #nav-bar {
-   box-shadow: none !important;
-   border-top: none !important;
- }
-#TabsToolbar {
- position: absolute;
- display: block;
- bottom: 0;
- width: 100vw;
- background-clip: padding-box;
- color: var(--toolbar-color);
- }
-#tabbrowser-tabs {
- width: 100vw;
- }
-#navigator-toolbox {
- position: relative;
- padding-bottom: calc( var(--tab-min-height) + 28px );
+/*
+ * Classic layout with tabs below the navigation bar.
+ * This keeps the modern Firefox styling while restoring
+ * the old placement of interface elements.
+ */
+
+/* navigation bar at the top */
+#nav-bar {
+  box-shadow: none !important;
+  border-top: none !important;
 }
-#main-window[tabsintitlebar][sizemode="maximized"]:not([inDOMFullscreen="true"]) #titlebar {
- height: 36px;
- }
-.titlebar-buttonbox-container { 
-position: fixed;
- right: 0;
- visibility: visible;
- display: block;
- }
- #TabsToolbar .titlebar-buttonbox-container,
- #TabsToolbar #window-controls {
-display: none;
- }
+
+#navigator-toolbox::after {
+  border-bottom: none !important;
+}
+
+/* place the tab bar at the bottom */
+#TabsToolbar {
+  position: absolute !important;
+  bottom: 0 !important;
+  width: 100vw !important;
+  background-clip: padding-box !important;
+}
+
+#tabbrowser-tabs {
+  width: 100vw !important;
+}
+
+/* reserve space for the tabs */
+#navigator-toolbox {
+  position: relative !important;
+  padding-bottom: calc(var(--tab-min-height) + 2px) !important;
+}
+
+/* keep window controls with the nav bar */
+.titlebar-buttonbox-container {
+  position: fixed !important;
+  right: 0;
+  visibility: visible !important;
+}
+
+/* hide duplicate controls from the tab bar */
+#TabsToolbar .titlebar-buttonbox-container,
+#TabsToolbar #window-controls {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- reposition Firefox tabs to the bottom
- keep the navigation bar (with the search bar) above tabs
- ensure window controls remain next to navigation bar

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68469f8e607c832992ca5399064ef76a